### PR TITLE
Fix construction of required parameters

### DIFF
--- a/pypx/base.py
+++ b/pypx/base.py
@@ -110,7 +110,7 @@ class Base():
         command_suffix =    ' -aec '    + self.aec
         command_suffix +=   ' -aet '    + self.aet
         command_suffix +=   ' '         + self.serverIP
-        command_suffix +=   ' '         + self.serverPort
+        command_suffix +=   ' '         + str(self.serverPort)
 
         return command_suffix
 


### PR DESCRIPTION
`serverPort` in commandSuffix() is being treated as an integer when constructing a string. This commit fixes that by converting it into a string.
Ref: https://github.com/FNNDSC/ChRIS_ultron_backEnd/issues/222#issuecomment-725556064