### PR TITLE
remove pypx.re from find.py

### DIFF
--- a/pypx/find.py
+++ b/pypx/find.py
@@ -23,7 +23,6 @@ from    dask                import  delayed, compute
 from    .base               import Base
 from    .move               import Move
 import  pypx
-import  pypx.re
 from    pypx                import smdb
 from    pypx                import report
 from    pypx                import do


### PR DESCRIPTION
It looks like we missed removing this line in find.py.